### PR TITLE
Allowed configuring the accounts.txt filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 ## Dev
 
 1. Create `.env` file with `AT_LOGIN`, `AT_PASSWORD`, `STARTER_PACK_URI` and `LIST_URI`
+    - Optionally set `BSKY_SYNC_CONFIG_FILE` (default: `accounts.txt`)
 2. `$ uv run --env-file .env sync.py`
 
 

--- a/sync.py
+++ b/sync.py
@@ -8,12 +8,13 @@ def main():
     # Setup these in an `.env` file, shell env or github actions.
     LOGIN = os.environ["AT_LOGIN"]
     PASSWORD = os.environ["AT_PASSWORD"]
+    CONFIG_FILE = os.environ.get("BSKY_SYNC_CONFIG_FILE", "accounts.txt")
     LISTS = [
         ("starter pack", os.environ["STARTER_PACK_URI"]),
         ("list", os.environ["LIST_URI"]),
     ]
 
-    with open("accounts.txt") as f:
+    with open(CONFIG_FILE) as f:
         expected = set(line.strip() for line in f.readlines() if line.strip())
 
     client = Client()


### PR DESCRIPTION
I needed this so that I can use a different file in my fork without having to deal with merge conflicts with your version-controlled accounts.txt

This will have a merge conflict with https://github.com/jaseemabid/bluesky-sync/pull/17, just bc that puts explanation of envvars into a sample.env file.